### PR TITLE
Added bytes sent and received to message event

### DIFF
--- a/zipkin.go
+++ b/zipkin.go
@@ -17,6 +17,7 @@ package zipkin // import "contrib.go.opencensus.io/exporter/zipkin"
 
 import (
 	"encoding/binary"
+	"fmt"
 	"strconv"
 
 	"github.com/openzipkin/zipkin-go/model"
@@ -182,9 +183,9 @@ func zipkinSpan(s *trace.SpanData, localEndpoint *model.Endpoint) model.SpanMode
 			}
 			switch m.EventType {
 			case trace.MessageEventTypeSent:
-				a.Value = "SENT"
+				a.Value = fmt.Sprintf("Sent %d bytes", m.UncompressedByteSize)
 			case trace.MessageEventTypeRecv:
-				a.Value = "RECV"
+				a.Value = fmt.Sprintf("Received %d bytes", m.UncompressedByteSize)
 			default:
 				a.Value = "<?>"
 			}

--- a/zipkin_test.go
+++ b/zipkin_test.go
@@ -108,7 +108,7 @@ func TestExport(t *testing.T) {
 					},
 					{
 						Timestamp: now,
-						Value:     "SENT",
+						Value:     "Sent 99 bytes",
 					},
 				},
 				Tags: map[string]string{


### PR DESCRIPTION
Added uncompressed bytes sent and received to address problem described here
https://github.com/census-instrumentation/opencensus-go/issues/1130

See screenshot.
![zipkin_with_bytes](https://user-images.githubusercontent.com/5554156/56702350-61108900-66b8-11e9-9e01-b00f642eabf8.png)
